### PR TITLE
Update from the upstream `nowide` repo:

### DIFF
--- a/nowide/convert.hpp
+++ b/nowide/convert.hpp
@@ -14,13 +14,13 @@
 
 namespace nowide {
     ///
-    /// \brief Template function that converts a buffer of UTF sequence in range [source_begin,source_end)
+    /// \brief Template function that converts a buffer of UTF sequences in range [source_begin,source_end)
     /// to the output \a buffer of size \a buffer_size.
     ///
-    /// In case of success a NUL terminated string returned (buffer), otherwise 0 is returned.
+    /// In case of success a NULL terminated string is returned (buffer), otherwise 0 is returned.
     ///
-    /// If there is not enough room in the buffer or the source sequence contains invalid UTF
-    /// 0 is returned, and the contend of the buffer is undefined.
+    /// If there is not enough room in the buffer or the source sequence contains invalid UTF,
+    /// 0 is returned, and the contents of the buffer are undefined.
     ///
     template<typename CharOut,typename CharIn>
     CharOut *basic_convert(CharOut *buffer,size_t buffer_size,CharIn const *source_begin,CharIn const *source_end)
@@ -64,10 +64,10 @@ namespace nowide {
     /// \endcond
 
     ///
-    /// Convert NUL terminated UTF source string to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert NULL terminated UTF source string to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline char *narrow(char *output,size_t output_size,wchar_t const *source)
@@ -75,10 +75,10 @@ namespace nowide {
         return basic_convert(output,output_size,source,details::basic_strend(source));
     }
     ///
-    /// Convert UTF text in range [begin,end) to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert UTF text in range [begin,end) to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline char *narrow(char *output,size_t output_size,wchar_t const *begin,wchar_t const *end)
@@ -86,10 +86,10 @@ namespace nowide {
         return basic_convert(output,output_size,begin,end);
     }
     ///
-    /// Convert NUL terminated UTF source string to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert NULL terminated UTF source string to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline wchar_t *widen(wchar_t *output,size_t output_size,char const *source)
@@ -97,10 +97,10 @@ namespace nowide {
         return basic_convert(output,output_size,source,details::basic_strend(source));
     }
     ///
-    /// Convert UTF text in range [begin,end) to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert UTF text in range [begin,end) to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline wchar_t *widen(wchar_t *output,size_t output_size,char const *begin,char const *end)

--- a/nowide/cstdio.hpp
+++ b/nowide/cstdio.hpp
@@ -33,7 +33,7 @@ namespace nowide {
 ///
 /// \brief Same as freopen but file_name and mode are UTF-8 strings
 ///
-/// In invalid UTF-8 given, NULL is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, NULL is returned and errno is set to EINVAL
 ///
 inline FILE *freopen(char const *file_name,char const *mode,FILE *stream)
 {
@@ -48,7 +48,7 @@ inline FILE *freopen(char const *file_name,char const *mode,FILE *stream)
 ///
 /// \brief Same as fopen but file_name and mode are UTF-8 strings
 ///
-/// In invalid UTF-8 given, NULL is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, NULL is returned and errno is set to EINVAL
 ///
 inline FILE *fopen(char const *file_name,char const *mode)
 {
@@ -63,7 +63,7 @@ inline FILE *fopen(char const *file_name,char const *mode)
 ///
 /// \brief Same as rename but old_name and new_name are UTF-8 strings
 ///
-/// In invalid UTF-8 given, -1 is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, -1 is returned and errno is set to EINVAL
 ///
 inline int rename(char const *old_name,char const *new_name)
 {
@@ -77,7 +77,7 @@ inline int rename(char const *old_name,char const *new_name)
 ///
 /// \brief Same as rename but name is UTF-8 string
 ///
-/// In invalid UTF-8 given, -1 is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, -1 is returned and errno is set to EINVAL
 ///
 inline int remove(char const *name)
 {

--- a/nowide/encoding_utf.hpp
+++ b/nowide/encoding_utf.hpp
@@ -46,7 +46,7 @@ namespace nowide{
         }
 
         ///
-        /// Convert a Unicode NUL terminated string \a str other Unicode encoding
+        /// Convert a Unicode NULL terminated string \a str other Unicode encoding
         ///
         template<typename CharOut,typename CharIn>
         std::basic_string<CharOut>

--- a/src/iostream.cpp
+++ b/src/iostream.cpp
@@ -23,16 +23,23 @@
 
 namespace nowide {
 namespace details {
+
+    namespace {
+        bool is_atty_handle(HANDLE h) 
+        {
+            if(h) {
+                DWORD dummy;
+                return GetConsoleMode(h,&dummy) == TRUE;
+            }
+            return false;
+        }
+    }
+
     class console_output_buffer : public std::streambuf {
     public:
         console_output_buffer(HANDLE h) :
-            handle_(h),
-            isatty_(false)
+            handle_(h)
         {
-            if(handle_) {
-                DWORD dummy;
-                isatty_ = GetConsoleMode(handle_,&dummy) == TRUE;
-            }
         }
     protected:
         int sync()
@@ -65,11 +72,6 @@ namespace details {
             char const *b = p;
             char const *e = p+n;
             DWORD size=0;
-            if(!isatty_) {
-                if(!WriteFile(handle_,p,n,&size,0) || static_cast<int>(size) != n)
-                    return -1;
-                return n;
-            }
             if(n > buffer_size)
                 return -1;
             wchar_t *out = wbuffer_;
@@ -90,20 +92,14 @@ namespace details {
         char buffer_[buffer_size];
         wchar_t wbuffer_[buffer_size]; // for null
         HANDLE handle_;
-        bool isatty_;
     };
     
     class console_input_buffer: public std::streambuf {
     public:
         console_input_buffer(HANDLE h) :
             handle_(h),
-            isatty_(false),
             wsize_(0)
         {
-            if(handle_) {
-                DWORD dummy;
-                isatty_ = GetConsoleMode(handle_,&dummy) == TRUE;
-            }
         } 
         
     protected:
@@ -160,12 +156,6 @@ namespace details {
         size_t read()
         {
             namespace uf = nowide::utf;
-            if(!isatty_) {
-                DWORD read_bytes = 0;
-                if(!ReadFile(handle_,buffer_,buffer_size,&read_bytes,0))
-                    return 0;
-                return read_bytes;
-            }
             DWORD read_wchars = 0;
             size_t n = wbuffer_size - wsize_;
             if(!ReadConsoleW(handle_,wbuffer_,n,&read_wchars,0))
@@ -183,7 +173,7 @@ namespace details {
             }
             
             if(c==uf::illegal)
-                return -1;
+                return 0;
             
             
             if(c==uf::incomplete) {
@@ -198,7 +188,6 @@ namespace details {
         char buffer_[buffer_size];
         wchar_t wbuffer_[buffer_size]; // for null
         HANDLE handle_;
-        bool isatty_;
         int wsize_;
         std::vector<char> pback_buffer_;
     };
@@ -214,19 +203,32 @@ namespace details {
             h = GetStdHandle(STD_ERROR_HANDLE);
             break;
         }
-        d.reset(new console_output_buffer(h));
-        std::ostream::rdbuf(d.get());
+        if(is_atty_handle(h)) {
+            d.reset(new console_output_buffer(h));
+            std::ostream::rdbuf(d.get());
+        }
+        else {
+            std::ostream::rdbuf( fd == 1 ? std::cout.rdbuf() : std::cerr.rdbuf() );
+        }
     }
-    
     winconsole_ostream::~winconsole_ostream()
     {
+        try {
+            flush();
+        }
+        catch(...){}
     }
 
     winconsole_istream::winconsole_istream() : std::istream(0)
     {
         HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
-        d.reset(new console_input_buffer(h));
-        std::istream::rdbuf(d.get());
+        if(is_atty_handle(h)) {
+            d.reset(new console_input_buffer(h));
+            std::istream::rdbuf(d.get());
+        }
+        else {
+            std::istream::rdbuf(std::cin.rdbuf());
+        }
     }
     
     winconsole_istream::~winconsole_istream()


### PR DESCRIPTION
Update from https://github.com/artyom-beilis/nowide.git.
Up to now we were up to date with 2d6b349, this commit
updates to ec9672b. Changes to the following files were excluded
(since those files are missing from this fork):

    doc/*, utf8_codecvt.hpp, standalone/convert,
    standalone/run_convert_and_build.sh